### PR TITLE
minor change, specifying frame delay on a per-image basis

### DIFF
--- a/BumpKit/BumpKit/GifEncoder.cs
+++ b/BumpKit/BumpKit/GifEncoder.cs
@@ -67,7 +67,7 @@ namespace BumpKit
         /// <param name="img">The image to add</param>
         /// <param name="x">The positioning x offset this image should be displayed at.</param>
         /// <param name="y">The positioning y offset this image should be displayed at.</param>
-        public void AddFrame(Image img, int x = 0, int y = 0, TimeSpan? delay = null)
+        public void AddFrame(Image img, int x = 0, int y = 0, TimeSpan? frameDelay = null)
         {
             using (var gifStream = new MemoryStream())
             {
@@ -76,7 +76,7 @@ namespace BumpKit
                 {
                     InitHeader(gifStream, img.Width, img.Height);
                 }
-                WriteGraphicControlBlock(gifStream, delay ?? FrameDelay);
+                WriteGraphicControlBlock(gifStream, frameDelay.GetValueOrDefault(FrameDelay));
                 WriteImageBlock(gifStream, !_isFirstImage, x, y, img.Width, img.Height);
             }
             _isFirstImage = false;


### PR DESCRIPTION
Hi, thanks for making Bumpkit available on nuget.  I wanted to suggest a minor change, letting each individual frame have its own delay specified (rather than use FrameDelay).  One can just update FrameDelay before each call to add an image, but I had to check the code to verify that would work.

Also, I'm still kind of learning how animated gifs work.  Am I right in understanding that the delay indicates how long that image will be shown, or is it the delay before that image specified is shown?

thanks
