### PR TITLE
Removes unnecessary byte.

### DIFF
--- a/BumpKit/BumpKit/GifEncoder.cs
+++ b/BumpKit/BumpKit/GifEncoder.cs
@@ -187,10 +187,9 @@ namespace BumpKit
 
         public void Dispose()
         {
-            // Complete Application Block
-            WriteByte(0);
             // Complete File
             WriteByte(FileTrailer);
+
             // Pushing data
             _stream.Flush();
         }


### PR DESCRIPTION
See the question I raised on [stackoverflow](http://stackoverflow.com/questions/26415305/animated-gif-encoder-error).

I'm wondering whether this is also related to #2 
