### PR TITLE
Updated `AddFrame` method to handle Gif as source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+/.vs

--- a/BumpKit/BumpKit/GifEncoder.cs
+++ b/BumpKit/BumpKit/GifEncoder.cs
@@ -71,6 +71,19 @@ namespace BumpKit
         {
             using (var gifStream = new MemoryStream())
             {
+                // if img is a gif, we need to convert it first.
+                if (ImageFormat.Gif.Equals(img.RawFormat))
+                {
+                    using (MemoryStream ms = new MemoryStream())
+                    {
+                        // save to memory
+                        img.Save(ms, ImageFormat.Png);
+                        ms.Seek(0, SeekOrigin.Begin);
+                        // pull it back out
+                        img = Image.FromStream(ms);
+                    }
+                }
+
                 img.Save(gifStream, ImageFormat.Gif);
                 if (_isFirstImage) // Steal the global color table info
                 {

--- a/BumpKit/BumpKit/GifEncoder.cs
+++ b/BumpKit/BumpKit/GifEncoder.cs
@@ -69,6 +69,9 @@ namespace BumpKit
         /// <param name="y">The positioning y offset this image should be displayed at.</param>
         public void AddFrame(Image img, int x = 0, int y = 0, TimeSpan? frameDelay = null)
         {
+            // assign to a variable used to make the frame.
+            Image imageToSave = img;
+
             using (var gifStream = new MemoryStream())
             {
                 // if img is a gif, we need to convert it first.
@@ -77,20 +80,24 @@ namespace BumpKit
                     using (MemoryStream ms = new MemoryStream())
                     {
                         // save to memory
-                        img.Save(ms, ImageFormat.Png);
+                        imageToSave.Save(ms, ImageFormat.Png);
                         ms.Seek(0, SeekOrigin.Begin);
                         // pull it back out
-                        img = Image.FromStream(ms);
+                        imageToSave = Image.FromStream(ms);
                     }
                 }
 
-                img.Save(gifStream, ImageFormat.Gif);
+                // save the image to the frame.
+                imageToSave.Save(gifStream, ImageFormat.Gif);
                 if (_isFirstImage) // Steal the global color table info
                 {
                     InitHeader(gifStream, img.Width, img.Height);
                 }
                 WriteGraphicControlBlock(gifStream, frameDelay.GetValueOrDefault(FrameDelay));
                 WriteImageBlock(gifStream, !_isFirstImage, x, y, img.Width, img.Height);
+
+                // dispose of the image saved to frame.
+                if (imageToSave != null) imageToSave.Dispose();
             }
             _isFirstImage = false;
         }

--- a/BumpKit/Demonstrations/Form1.Designer.cs
+++ b/BumpKit/Demonstrations/Form1.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.button1 = new System.Windows.Forms.Button();
+            this.btnOpen = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this._rotateOverflow = new System.Windows.Forms.Panel();
             this.label5 = new System.Windows.Forms.Label();
@@ -54,15 +54,15 @@
             ((System.ComponentModel.ISupportInitialize)(this._gifGeneration)).BeginInit();
             this.SuspendLayout();
             // 
-            // button1
+            // btnOpen
             // 
-            this.button1.Location = new System.Drawing.Point(12, 12);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(792, 23);
-            this.button1.TabIndex = 0;
-            this.button1.Text = "Run Demonstrations";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.btnOpen.Location = new System.Drawing.Point(12, 12);
+            this.btnOpen.Name = "btnOpen";
+            this.btnOpen.Size = new System.Drawing.Size(792, 23);
+            this.btnOpen.TabIndex = 0;
+            this.btnOpen.Text = "Run Demonstrations";
+            this.btnOpen.UseVisualStyleBackColor = true;
+            this.btnOpen.Click += new System.EventHandler(this.btnOpen_Click);
             // 
             // groupBox1
             // 
@@ -261,7 +261,7 @@
             this.ClientSize = new System.Drawing.Size(816, 354);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.btnOpen);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -276,7 +276,7 @@
 
         #endregion
 
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button btnOpen;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.Panel _scaleToFit;
         private System.Windows.Forms.Label label1;

--- a/BumpKit/Demonstrations/Form1.cs
+++ b/BumpKit/Demonstrations/Form1.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
+﻿using BumpKit;
+using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using BumpKit;
 
 namespace Demonstrations
 {
@@ -19,9 +14,14 @@ namespace Demonstrations
             InitializeComponent();
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void btnOpen_Click(object sender, EventArgs e)
         {
-            var dlg = new OpenFileDialog { Title = "Please select an image to open:", Filter = "Jpeg|*.jpg|Jpeg|*.jpeg|Png|*.png|Bitmap|*.bmp" };
+            var dlg = new OpenFileDialog 
+            { 
+                Title = "Please select an image to open:", 
+                Filter = "All Supported Images|*gif; *jpg; *png; *.bmp|Gif|*.gif|Jpeg|*.jpg|Jpeg|*.jpeg|Png|*.png|Bitmap|*.bmp" 
+            };
+
             if (dlg.ShowDialog() != DialogResult.OK)
                 return;
 
@@ -38,7 +38,7 @@ namespace Demonstrations
 
             // Rotate and fit
             _rotateFit.BackgroundImage = img.ScaleToFit(_rotateFit.Size, false).Rotate(45, ScalingMode.FitContent).ScaleToFit(_rotateOverflow.Size);
-            
+
             // Rotate and overflow
             _rotateOverflow.BackgroundImage = img.ScaleToFit(_rotateOverflow.Size, false).Rotate(45);
 
@@ -86,7 +86,7 @@ namespace Demonstrations
             using (var gfx = Graphics.FromImage(_textGen.BackgroundImage))
             {
                 gfx.DrawString("A B C 1 2 3", new Font(FontFamily.Families.First(f => f.Name.Contains("Times")), 15), Brushes.Green, 15, 25, 10,
-                    new[] {Color.Yellow, Color.Blue, Color.Red, Color.Green, Color.Purple, Color.Black},
+                    new[] { Color.Yellow, Color.Blue, Color.Red, Color.Green, Color.Purple, Color.Black },
                     new[] { 0, (float).20, (float).40, (float).60, (float).80, 1 });
             }
         }

--- a/BumpKit/Demonstrations/Program.cs
+++ b/BumpKit/Demonstrations/Program.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using BumpKit;
+using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Text;
-using System.Linq;
-using System.Windows.Forms;
-using BumpKit;
+using System.IO;
 
 namespace Demonstrations
 {
@@ -18,9 +13,31 @@ namespace Demonstrations
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Demonstrations());
+            //Application.EnableVisualStyles();
+            //Application.SetCompatibleTextRenderingDefault(false);
+            //Application.Run(new Demonstrations());
+
+
+            using (FileStream fs = new FileStream(@"E:\123.gif", FileMode.OpenOrCreate))
+            {
+                GifEncoder gifEncoder = new GifEncoder(fs);
+
+                foreach (string item in Directory.EnumerateFiles(@"E:\Pictures"))
+                {
+                    try
+                    {
+                        Image img = Image.FromFile(item);
+                        gifEncoder.AddFrame(Image.FromFile(item));
+                    }
+                    catch
+                    {
+
+                    }
+
+                }
+            }
+
+
         }
     }
 }


### PR DESCRIPTION
In Issue #8, there is a problem where if the source of the image is an animated gif, the result will be a corrupted animated gif. Due to the nature of animated gifs, the frame only contains what has changed from one frame to the next (similar to interleaved video). By converting the frame to another format, and using that as the source, the result is no longer corrupted.